### PR TITLE
#4 [FEAT] 제품 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopthapse/www/HapseProject/controller/ProductController.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/controller/ProductController.java
@@ -1,0 +1,24 @@
+package org.sopthapse.www.HapseProject.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.domain.Message;
+import org.sopthapse.www.HapseProject.service.ProductService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductController {
+    private final ProductService productService;
+
+    @GetMapping("/product/{productType}/items")
+    public ResponseEntity<Message> getProductsByType(@PathVariable Long productType) {
+        return ResponseEntity.ok().body(Message.of(
+                true,
+                "상품 목록 조회 성공",
+                productService.getProductsByType(productType)
+        ));
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/domain/Message.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/domain/Message.java
@@ -1,0 +1,11 @@
+package org.sopthapse.www.HapseProject.domain;
+
+public record Message(
+        boolean success,
+        String msg,
+        Object data
+) {
+    public static Message of(boolean success, String msg, Object data) {
+        return new Message(success, msg, data);
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/domain/Product.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/domain/Product.java
@@ -1,0 +1,30 @@
+package org.sopthapse.www.HapseProject.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "product")
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long productType;
+    private String productName;
+    private String productCost;
+    private String productImgUrl;
+
+    @Builder
+    public Product(Long productType, String productName, String productCost, String productImgUrl) {
+        this.productType = productType;
+        this.productName = productName;
+        this.productCost = productCost;
+        this.productImgUrl = productImgUrl;
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/dto/response/Product/ProductGetResponse.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/dto/response/Product/ProductGetResponse.java
@@ -1,0 +1,17 @@
+package org.sopthapse.www.HapseProject.dto.response.Product;
+
+import org.sopthapse.www.HapseProject.domain.Product;
+
+public record ProductGetResponse(
+        String productName,
+        String productCost,
+        String productImgUrl
+) {
+    public static ProductGetResponse of(Product product) {
+        return new ProductGetResponse(
+                product.getProductName(),
+                product.getProductCost(),
+                product.getProductImgUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/repository/ProductRepository.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/repository/ProductRepository.java
@@ -1,0 +1,12 @@
+package org.sopthapse.www.HapseProject.repository;
+
+import org.sopthapse.www.HapseProject.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findAllByProductType(Long type);
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/service/ProductService.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/service/ProductService.java
@@ -1,0 +1,20 @@
+package org.sopthapse.www.HapseProject.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.dto.response.Product.ProductGetResponse;
+import org.sopthapse.www.HapseProject.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+    private final ProductRepository productRepository;
+    public List<ProductGetResponse> getProductsByType(Long productType) {
+        return productRepository.findAllByProductType(productType).stream()
+                .map(ProductGetResponse::of)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
- close #4 

## 📝 Summary
- 전체 API 공용 응답 객체 구현 - `/domin/Message`
- 제품 타입을 파라미터로 받아, 해당 타입의 제품 목록을 조회하는 API 구현
  - 제품 도메인 설계 - `/domain/Product`
  - 제품 컨트롤러 구현 - `/controller/ProductController`
  - 제품 서비스 로직 구현 - `/service/ProductService`
  - 제품 레포지토리 구현 - `/repository/ProductRepository`
  - 제품 응답 객체 구현 - `/dto/response/Product/ProductGetResponse`
 
![image](https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/109871579/d6185b4f-0658-432b-a2c7-2b97fead70a0)

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
1. 모든 API 응답 형식을 지정하는 공용 응답 객체 `Message`를 구현해보았는데, 혹시나 개선할 점이 있다면 말씀해주세요! 😃
2. 파라미터로 제품 타입을 받을 때, 타입이름으로 받지 않고 고유 Long 값으로 받게 구현했습니다!

| 고유 Long 값 | 제품 타입|
|--------|--------|
| 1 | Mac |
| 2 | iPhone|
| 3 | iPad|
| 4 | Apple Watch |
| 5 | AirPods | 
| 6 | AirTag | 
| 7 | Apple TV 4K | 
| 8 | 액세사리 | 

## 📬 Reference