### PR TITLE
#6 [FEAT] iPad Pro 배송 도착 정보 조회 API 구현

### DIFF
--- a/src/main/java/org/sopthapse/www/HapseProject/controller/PaymentController.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/controller/PaymentController.java
@@ -1,0 +1,23 @@
+package org.sopthapse.www.HapseProject.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.domain.Message;
+import org.sopthapse.www.HapseProject.service.PaymentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/ipad-pro")
+@RequiredArgsConstructor
+public class PaymentController {
+    private final PaymentService paymentService;
+
+    @GetMapping("/delivery-date")
+    public ResponseEntity<Message> getDeliveryDate() {
+        return ResponseEntity.ok().body(Message.of(
+                true,
+                "iPad Pro 배송 도착 정보 조회 성공",
+                paymentService.getDeliveryDate()
+        ));
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/service/PaymentService.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/service/PaymentService.java
@@ -1,0 +1,15 @@
+package org.sopthapse.www.HapseProject.service;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class PaymentService {
+
+    public String getDeliveryDate() {
+        LocalDate deliveryDate = LocalDate.now().plusDays(3);
+        return deliveryDate.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
- close #6 

## 📝 Summary
- API를 호출한 날짜에서 3일 뒤 날짜를 반환하는 iPad Pro 배송 도착 정보 조회 API 구현
  - 구입 컨트롤러 클래스에 배송 도착 정보 조회 API 구현 - `/controller/PaymentController`
  - 구입 서비스 클래스에 배송 도착 정보 조회 기능 구현 - `/service/PaymentService`

![image](https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/109871579/32f4fa00-f624-4674-98c7-1067394ef6b7)

## 🙏 Question & PR point
배송 예상 도착일을 API 호출한 날로부터 3일 뒤인 날짜로 설정했는데, 적당할까요 ㅎㅅㅎ!?

## 📬 Reference