### PR TITLE
#5 [FEAT] 아이패드 뷰 내의 모든 제품 정보 조회 API 구현

### DIFF
--- a/src/main/java/org/sopthapse/www/HapseProject/controller/IpadviewItemsController.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/controller/IpadviewItemsController.java
@@ -1,0 +1,23 @@
+package org.sopthapse.www.HapseProject.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.domain.Message;
+import org.sopthapse.www.HapseProject.service.IpadviewItemsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class IpadviewItemsController {
+    private final IpadviewItemsService ipadviewItemsService;
+
+    @GetMapping("/ipad/items")
+    public ResponseEntity<Message> getIpadviewItems() {
+        return ResponseEntity.ok().body(Message.of(
+                true,
+                "아이패드 뷰 내 모든 제품 정보 조회 성공",
+                ipadviewItemsService.getIpadviewItems()
+        ));
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/domain/IpadviewItems.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/domain/IpadviewItems.java
@@ -1,0 +1,28 @@
+package org.sopthapse.www.HapseProject.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "ipadview_items")
+public class IpadviewItems {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String productName;
+    private String productCost;
+    private String productImgUrl;
+
+    @Builder
+    public IpadviewItems(String productName, String productCost, String productImgUrl) {
+        this.productName = productName;
+        this.productCost = productCost;
+        this.productImgUrl = productImgUrl;
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/domain/IpadviewItems.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/domain/IpadviewItems.java
@@ -15,12 +15,14 @@ public class IpadviewItems {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String productAsset;
     private String productName;
     private String productCost;
     private String productImgUrl;
 
     @Builder
-    public IpadviewItems(String productName, String productCost, String productImgUrl) {
+    public IpadviewItems(String productAsset, String productName, String productCost, String productImgUrl) {
+        this.productAsset = productAsset;
         this.productName = productName;
         this.productCost = productCost;
         this.productImgUrl = productImgUrl;

--- a/src/main/java/org/sopthapse/www/HapseProject/dto/response/IpadviewItems/IpadviewItemsGetResponse.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/dto/response/IpadviewItems/IpadviewItemsGetResponse.java
@@ -1,0 +1,17 @@
+package org.sopthapse.www.HapseProject.dto.response.IpadviewItems;
+
+import org.sopthapse.www.HapseProject.domain.IpadviewItems;
+
+public record IpadviewItemsGetResponse(
+        String productName,
+        String productCost,
+        String productImgUrl
+) {
+    public static IpadviewItemsGetResponse of(IpadviewItems ipadviewItems) {
+        return new IpadviewItemsGetResponse(
+                ipadviewItems.getProductName(),
+                ipadviewItems.getProductCost(),
+                ipadviewItems.getProductImgUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/dto/response/IpadviewItems/IpadviewItemsGetResponse.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/dto/response/IpadviewItems/IpadviewItemsGetResponse.java
@@ -3,12 +3,14 @@ package org.sopthapse.www.HapseProject.dto.response.IpadviewItems;
 import org.sopthapse.www.HapseProject.domain.IpadviewItems;
 
 public record IpadviewItemsGetResponse(
+        String productAsset,
         String productName,
         String productCost,
         String productImgUrl
 ) {
     public static IpadviewItemsGetResponse of(IpadviewItems ipadviewItems) {
         return new IpadviewItemsGetResponse(
+                ipadviewItems.getProductAsset(),
                 ipadviewItems.getProductName(),
                 ipadviewItems.getProductCost(),
                 ipadviewItems.getProductImgUrl()

--- a/src/main/java/org/sopthapse/www/HapseProject/repository/IpadviewItemsRepository.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/repository/IpadviewItemsRepository.java
@@ -1,0 +1,9 @@
+package org.sopthapse.www.HapseProject.repository;
+
+import org.sopthapse.www.HapseProject.domain.IpadviewItems;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IpadviewItemsRepository extends JpaRepository<IpadviewItems, Long> {
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/service/IpadviewItemsService.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/service/IpadviewItemsService.java
@@ -1,0 +1,21 @@
+package org.sopthapse.www.HapseProject.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.dto.response.IpadviewItems.IpadviewItemsGetResponse;
+import org.sopthapse.www.HapseProject.repository.IpadviewItemsRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class IpadviewItemsService {
+    private final IpadviewItemsRepository ipadviewItemsRepository;
+
+    public List<IpadviewItemsGetResponse> getIpadviewItems() {
+        return ipadviewItemsRepository.findAll().stream()
+                .map(IpadviewItemsGetResponse::of)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
- close #5 

## 📝 Summary
- 아이패드 뷰 내의 모든 제품 정보를 조회하는 API 구현
  - 아이패드 뷰 제품 도메인 설계 - `/domain/IpadviewItems`
  - 아이패드 뷰 제품 컨트롤러 구현 - `/controller/IpadviewItemsController`
  - 아이패드 뷰 제품 서비스 로직 구현 - `/service/IpadviewItemsService`
  - 아이패드 뷰 제품 레포지토리 구현 - `/repository/IpadviewItemsRepository`
  - 아이패드 뷰 제품 응답 객체 구현 - `/dto/response/Product/IpadviewItemsGetResponse`

![image](https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/109871579/ecbad01f-8294-47df-8adb-73b718aef0d8)

## 🙏 Question & PR point
아이패드 뷰 제품 도메인 이름 `IpadviewItems`이 살짝 별로인 것 같기도 해서,, 다시 이름을 지어야 하나 고민이 되는데..😂
생각을 듣고 싶습니다!!!

## 📬 Reference
