### PR TITLE
#3 [FEAT] iPad Pro 악세서리 정보 조회 API 구현

### DIFF
--- a/src/main/java/org/sopthapse/www/HapseProject/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/common/advice/ControllerExceptionAdvice.java
@@ -1,0 +1,25 @@
+package org.sopthapse.www.HapseProject.common.advice;
+
+import org.sopthapse.www.HapseProject.common.exception.BaseException;
+import org.sopthapse.www.HapseProject.common.resopnse.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerExceptionAdvice {
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ApiResponse> handleGlobalException(BaseException ex) {
+        return ResponseEntity.status(ex.getStatusCode())
+                .body(ApiResponse.fail(ex.getStatusCode(), ex.getResponseMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse>  handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
+    }
+
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/common/exception/BadRequestException.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/common/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package org.sopthapse.www.HapseProject.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends BaseException {
+
+    public BadRequestException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+
+    public BadRequestException(String responseMessage) {
+        super(HttpStatus.BAD_REQUEST, responseMessage);
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/common/exception/BaseException.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/common/exception/BaseException.java
@@ -1,0 +1,29 @@
+package org.sopthapse.www.HapseProject.common.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BaseException extends RuntimeException {
+
+    HttpStatus statusCode;
+    String responseMessage;
+
+    public BaseException(HttpStatus statusCode) {
+        super();
+        this.statusCode = statusCode;
+    }
+
+    public BaseException(HttpStatus statusCode, String responseMessage) {
+        super(responseMessage);
+        this.statusCode = statusCode;
+        this.responseMessage = responseMessage;
+    }
+
+    public int getStatusCode() {
+        return this.statusCode.value();
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/common/resopnse/ApiResponse.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/common/resopnse/ApiResponse.java
@@ -1,0 +1,24 @@
+package org.sopthapse.www.HapseProject.common.resopnse;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final int status;
+    private final boolean success;
+    private final String message;
+    private T data;
+
+    public static ApiResponse fail(int status, String message) {
+        return ApiResponse.builder()
+                .status(status)
+                .success(false)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/controller/PaymentController.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/controller/PaymentController.java
@@ -1,0 +1,23 @@
+package org.sopthapse.www.HapseProject.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.domain.Message;
+import org.sopthapse.www.HapseProject.service.PaymentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/ipad-pro")
+@RequiredArgsConstructor
+public class PaymentController {
+    private final PaymentService paymentService;
+
+    @PostMapping("/{modelType}/accessory")
+    public ResponseEntity<Message> getAccessoryByModelType(@PathVariable Long modelType) {
+        return ResponseEntity.ok().body(Message.of(
+                true,
+                "iPad Pro 악세서리 제품 정보 조회 성공",
+                paymentService.getAccessoryByModelType(modelType)
+        ));
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/dto/response/Accessory/AccessoryGetResponse.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/dto/response/Accessory/AccessoryGetResponse.java
@@ -3,15 +3,15 @@ package org.sopthapse.www.HapseProject.dto.response.Accessory;
 import java.util.List;
 
 public record AccessoryGetResponse(
-        String name,
-        String cost,
-        List<String> imgUrls
+        String accessoryName,
+        String accessoryCost,
+        List<String> accessoryImgUrls
 ) {
-    public static AccessoryGetResponse of(String modelType, int cost, List<String> imgUrls) {
+    public static AccessoryGetResponse of(String modelType, int accessoryCost, List<String> accessoryImgUrls) {
         return new AccessoryGetResponse(
                 String.format("iPad Pro %s용 Magic Keyboard - 한국어 - 화이트", modelType),
-                String.format("%,d", cost),
-                imgUrls
+                String.format("%,d", accessoryCost),
+                accessoryImgUrls
         );
     }
 }

--- a/src/main/java/org/sopthapse/www/HapseProject/dto/response/Accessory/AccessoryGetResponse.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/dto/response/Accessory/AccessoryGetResponse.java
@@ -1,0 +1,17 @@
+package org.sopthapse.www.HapseProject.dto.response.Accessory;
+
+import java.util.List;
+
+public record AccessoryGetResponse(
+        String name,
+        String cost,
+        List<String> imgUrls
+) {
+    public static AccessoryGetResponse of(String modelType, int cost, List<String> imgUrls) {
+        return new AccessoryGetResponse(
+                String.format("iPad Pro %s용 Magic Keyboard - 한국어 - 화이트", modelType),
+                String.format("%,d", cost),
+                imgUrls
+        );
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/service/PaymentService.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/service/PaymentService.java
@@ -1,5 +1,6 @@
 package org.sopthapse.www.HapseProject.service;
 
+import org.sopthapse.www.HapseProject.common.exception.BadRequestException;
 import org.sopthapse.www.HapseProject.dto.response.Accessory.AccessoryGetResponse;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +23,6 @@ public class PaymentService {
         if(modelType == 2) {
             return AccessoryGetResponse.of("12.9(6세대)", 519000, imgUrls);
         }
-        throw new IllegalArgumentException("modelType이 잘못되었습니다.");
+        throw new BadRequestException("modelType이 잘못되었습니다.");
     }
 }

--- a/src/main/java/org/sopthapse/www/HapseProject/service/PaymentService.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/service/PaymentService.java
@@ -1,0 +1,27 @@
+package org.sopthapse.www.HapseProject.service;
+
+import org.sopthapse.www.HapseProject.dto.response.Accessory.AccessoryGetResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PaymentService {
+
+    public AccessoryGetResponse getAccessoryByModelType(Long modelType) {
+        List<String> imgUrls = List.of(
+                "https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/109871579/d6469f5b-33d0-45e0-b341-6ed16d7ec14b",
+                "https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/109871579/de52d722-8da7-4706-a721-a3c3d74b99ad",
+                "https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/109871579/87c95758-94cb-4966-a40c-127840af8002",
+                "https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/109871579/a2dd6198-f6ac-4de6-a6dc-fcff4e6347fe",
+                "https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/109871579/bf088672-5838-4922-b1e2-e882ed4a1bfb"
+        );
+        if(modelType == 1) {
+            return AccessoryGetResponse.of("11(4세대)", 449000, imgUrls);
+        }
+        if(modelType == 2) {
+            return AccessoryGetResponse.of("12.9(6세대)", 519000, imgUrls);
+        }
+        throw new IllegalArgumentException("modelType이 잘못되었습니다.");
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
- close #3 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- iPad Pro의 모델 타입을 파라미터로 받아, 해당 타입의 악세서리 정보를 조회하는 API 구현
  - 구입 컨트롤러 클래스에 악세서리 정보 조회 API 구현 - `/controller/PaymentController`
  - 구입 서비스 클래스에 악세서리 정보 조회 기능 구현 - `/service/PaymentService`
  - 악세서리 응답 객체 구현 - `/dto/response/Accessory/AccessoryGetResponse`
 
![image](https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/109871579/2f9fb67b-47d8-4242-891c-1fc65f3fe4fe)

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- `해당 악세서리 조회 API`
- `iPad Pro 배송 도착 정보 조회 API` 

두 API 모두 iPad Pro 구입하기 페이지와 연관이 있어, 하나의 클래스에 두 API를 모두 구현했습니다!
혹시 더 나은 구현 방식이 있다면 말씀해주세요!!

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
