### PR TITLE
[FEAT] 메인 뷰 상품 정보 조회API 구현

### DIFF
--- a/src/main/java/org/sopthapse/www/HapseProject/controller/MainController.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/controller/MainController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopthapse.www.HapseProject.domain.Message;
 import org.sopthapse.www.HapseProject.service.MainCategoryService;
 import org.sopthapse.www.HapseProject.service.MainInformationService;
+import org.sopthapse.www.HapseProject.service.MainViewItemsService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MainController {
     private final MainCategoryService mainCategoryService;
     private final MainInformationService mainInformationService;
+    private final MainViewItemsService mainViewItemsService;
 
     @GetMapping("/category")
     public ResponseEntity<Message> getMainCategory() {
@@ -31,6 +33,15 @@ public class MainController {
                 true,
                 "하단 안내 문구 조회 성공",
                 mainInformationService.getMainInformation()
+        ));
+    }
+
+    @GetMapping("/items")
+    public ResponseEntity<Message> getMainViewItems() {
+        return ResponseEntity.ok().body(Message.of(
+                true,
+                "메인 뷰 내의 제품 정보 조회 성공",
+                mainViewItemsService.getMainviewItems()
         ));
     }
 }

--- a/src/main/java/org/sopthapse/www/HapseProject/controller/MainController.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/controller/MainController.java
@@ -3,6 +3,7 @@ package org.sopthapse.www.HapseProject.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopthapse.www.HapseProject.domain.Message;
 import org.sopthapse.www.HapseProject.service.MainCategoryService;
+import org.sopthapse.www.HapseProject.service.MainInformationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MainController {
     private final MainCategoryService mainCategoryService;
+    private final MainInformationService mainInformationService;
 
     @GetMapping("/category")
     public ResponseEntity<Message> getMainCategory() {
@@ -20,6 +22,15 @@ public class MainController {
                 true,
                 "카테고리 조회 성공",
                 mainCategoryService.getMainCategory()
+        ));
+    }
+
+    @GetMapping("/information")
+    public ResponseEntity<Message> getMainInformation() {
+        return ResponseEntity.ok().body(Message.of(
+                true,
+                "하단 안내 문구 조회 성공",
+                mainInformationService.getMainInformation()
         ));
     }
 }

--- a/src/main/java/org/sopthapse/www/HapseProject/controller/MainController.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/controller/MainController.java
@@ -1,0 +1,25 @@
+package org.sopthapse.www.HapseProject.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.domain.Message;
+import org.sopthapse.www.HapseProject.service.MainCategoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/main")
+@RequiredArgsConstructor
+public class MainController {
+    private final MainCategoryService mainCategoryService;
+
+    @GetMapping("/category")
+    public ResponseEntity<Message> getMainCategory() {
+        return ResponseEntity.ok().body(Message.of(
+                true,
+                "카테고리 조회 성공",
+                mainCategoryService.getMainCategory()
+        ));
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/domain/Information.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/domain/Information.java
@@ -15,7 +15,7 @@ public class Information {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 800)
+    @Column(length = 3000)
     private String content;
 
     @Builder

--- a/src/main/java/org/sopthapse/www/HapseProject/domain/Information.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/domain/Information.java
@@ -1,0 +1,25 @@
+package org.sopthapse.www.HapseProject.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "information")
+public class Information {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 800)
+    private String content;
+
+    @Builder
+    public Information(String content){
+        this.content = content;
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/domain/MainCategory.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/domain/MainCategory.java
@@ -1,0 +1,29 @@
+package org.sopthapse.www.HapseProject.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "main_category")
+public class MainCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "main_category_name")
+    private String mainCategoryName;
+
+    @Column(name = "main_category_img")
+    private String mainCategoryImg;
+
+    @Builder
+    public MainCategory(String mainCategoryName, String mainCategoryImg) {
+        this.mainCategoryName = mainCategoryName;
+        this.mainCategoryImg = mainCategoryImg;
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/domain/MainViewItems.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/domain/MainViewItems.java
@@ -1,0 +1,29 @@
+package org.sopthapse.www.HapseProject.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "main_items")
+public class MainViewItems {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "main_items_asset")
+    private String mainItemsAsset;
+
+    @Column(name = "main_items_name")
+    private String mainItemsName;
+
+    @Column(name = "main_items_cost")
+    private String mainItemsCost;
+
+    @Column(name = "main_category_img")
+    private String mainCategoryImg;
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/dto/response/Main/MainCategoryGetResponse.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/dto/response/Main/MainCategoryGetResponse.java
@@ -1,0 +1,17 @@
+package org.sopthapse.www.HapseProject.dto.response.Main;
+
+import org.sopthapse.www.HapseProject.domain.MainCategory;
+
+public record MainCategoryGetResponse(
+    Long mainCategoryId,
+    String mainCategoryName,
+    String mainCategoryImg
+){
+    public static MainCategoryGetResponse of(MainCategory mainCategory){
+        return new MainCategoryGetResponse(
+                mainCategory.getId(),
+                mainCategory.getMainCategoryName(),
+                mainCategory.getMainCategoryImg()
+        );
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/dto/response/Main/MainInformationGetResponse.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/dto/response/Main/MainInformationGetResponse.java
@@ -1,0 +1,16 @@
+package org.sopthapse.www.HapseProject.dto.response.Main;
+
+import org.sopthapse.www.HapseProject.domain.Information;
+
+public record MainInformationGetResponse(
+        Long id,
+        String content
+
+) {
+    public static MainInformationGetResponse of(Information information){
+        return new MainInformationGetResponse(
+                information.getId(),
+                information.getContent()
+        );
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/dto/response/Main/MainviewItemsGetResponse.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/dto/response/Main/MainviewItemsGetResponse.java
@@ -1,0 +1,21 @@
+package org.sopthapse.www.HapseProject.dto.response.Main;
+
+import org.sopthapse.www.HapseProject.domain.MainViewItems;
+
+import java.util.SimpleTimeZone;
+
+public record MainviewItemsGetResponse(
+        String mainItemsAsset,
+        String mainItemsName,
+        String mainItemsPrice,
+        String mainCategoryImg
+) {
+    public static MainviewItemsGetResponse of(MainViewItems mainViewItems){
+        return new MainviewItemsGetResponse(
+                mainViewItems.getMainItemsAsset(),
+                mainViewItems.getMainItemsName(),
+                mainViewItems.getMainItemsCost(),
+                mainViewItems.getMainCategoryImg()
+        );
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/repository/MainCategoryRepository.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/repository/MainCategoryRepository.java
@@ -1,0 +1,9 @@
+package org.sopthapse.www.HapseProject.repository;
+
+import org.sopthapse.www.HapseProject.domain.MainCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MainCategoryRepository extends JpaRepository<MainCategory, Long> {
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/repository/MainInformationRepository.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/repository/MainInformationRepository.java
@@ -1,0 +1,9 @@
+package org.sopthapse.www.HapseProject.repository;
+
+import org.sopthapse.www.HapseProject.domain.Information;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MainInformationRepository extends JpaRepository<Information, Long> {
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/repository/MainViewItemsRepository.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/repository/MainViewItemsRepository.java
@@ -1,0 +1,9 @@
+package org.sopthapse.www.HapseProject.repository;
+
+import org.sopthapse.www.HapseProject.domain.MainViewItems;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MainViewItemsRepository extends JpaRepository<MainViewItems, Long> {
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/service/MainCategoryService.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/service/MainCategoryService.java
@@ -1,0 +1,21 @@
+package org.sopthapse.www.HapseProject.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.dto.response.Main.MainCategoryGetResponse;
+import org.sopthapse.www.HapseProject.repository.MainCategoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MainCategoryService {
+    private final MainCategoryRepository mainCategoryRepository;
+
+    public List<MainCategoryGetResponse> getMainCategory() {
+        return mainCategoryRepository.findAll().stream()
+                .map(MainCategoryGetResponse::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/service/MainInformationService.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/service/MainInformationService.java
@@ -1,0 +1,21 @@
+package org.sopthapse.www.HapseProject.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.dto.response.Main.MainInformationGetResponse;
+import org.sopthapse.www.HapseProject.repository.MainInformationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MainInformationService {
+    private final MainInformationRepository mainInformationRepository;
+
+    public List<MainInformationGetResponse> getMainInformation() {
+        return mainInformationRepository.findAll().stream()
+                .map(MainInformationGetResponse::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/sopthapse/www/HapseProject/service/MainViewItemsService.java
+++ b/src/main/java/org/sopthapse/www/HapseProject/service/MainViewItemsService.java
@@ -1,0 +1,21 @@
+package org.sopthapse.www.HapseProject.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopthapse.www.HapseProject.dto.response.Main.MainviewItemsGetResponse;
+import org.sopthapse.www.HapseProject.repository.MainViewItemsRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MainViewItemsService {
+    private final MainViewItemsRepository mainViewItemsRepository;
+
+    public List<MainviewItemsGetResponse> getMainviewItems() {
+        return mainViewItemsRepository.findAll().stream()
+                .map(MainviewItemsGetResponse::of)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #12 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 메인 뷰에 있는 상품들의 사진, 가격, 제목을 조회하는 API를 구현했습니다.
<img width="1334" alt="스크린샷 2023-11-23 오전 12 57 48" src="https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Server/assets/97835512/9557815b-bc20-41f9-a9b5-617ec42898e6">

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
